### PR TITLE
destory command struct in heap when deinit

### DIFF
--- a/src/zli.zig
+++ b/src/zli.zig
@@ -96,6 +96,7 @@ pub const Command = struct {
         }
         self.commands_by_name.deinit();
         self.commands_by_shortcut.deinit();
+        self.allocator.destroy(self);
     }
 
     pub fn listCommands(self: *const Command) !void {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/75284210-334b-45a0-8ae0-bb5536a560b3)
When using GPA, a memory leak error occurs because the `Command` created on the heap is not released during `deinit`.

Minimum reproduction example (change the allocator of the sample code to the GPA allocator):
```zig
const std = @import("std");
const root = @import("cli/root.zig");

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}).init;
    defer _ = gpa.deinit();
    const allocator = gpa.allocator();

    var cli = try root.build(allocator);
    defer cli.deinit();

    try cli.execute();
}
```