### PR TITLE
Add support for command aliases and update version to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ All batteries included.
 [![Zig Version](https://img.shields.io/badge/Zig_Version-0.14.1-orange.svg?logo=zig)](README.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-lightgrey.svg?logo=cachet)](LICENSE)
 [![Built by xcaeser](https://img.shields.io/badge/Built%20by-@xcaeser-blue)](https://github.com/xcaeser)
-[![Version](https://img.shields.io/badge/ZLI-v3.5.3-green)](https://github.com/xcaeser/zli/releases)
+[![Version](https://img.shields.io/badge/ZLI-v3.6.0-green)](https://github.com/xcaeser/zli/releases)
 
 > 🧱 Each command is modular and self-contained.
-> inspired by Cobra (Go) and clap (Rust).
+> New: command aliases!
 
 ## 📚 Documentation
 
@@ -30,7 +30,7 @@ See [docs.md](docs.md) for full usage, examples, and internals.
 ## 📦 Installation
 
 ```sh
-zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.5.3.tar.gz
+zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.6.0.tar.gz
 ```
 
 Add to your `build.zig`:
@@ -176,7 +176,7 @@ fn show(ctx: zli.CommandContext) !void {
 - [x] Pretty-aligned help for flags & args
 - [x] Named access: `ctx.getArg("name")`
 - [x] Clean usage output like Cobra
-- [ ] Command aliases
+- [x ] Command aliases
 - [ ] Persistent flags
 
 ## 📝 License

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zli,
-    .version = "3.5.3",
+    .version = "3.6.0",
     .fingerprint = 0x5b01c9c3a623e52d, // Changing this has security and trust implications.
     .minimum_zig_version = "0.14.0",
     .dependencies = .{},

--- a/docs.md
+++ b/docs.md
@@ -105,10 +105,10 @@ Positional arguments are values passed to a command after its name and flags, id
 1.  Fetch `zli` as a dependency using Zig's package manager:
 
     ```sh
-    zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.5.3.tar.gz
+    zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.6.0.tar.gz
     ```
 
-    (Replace `v3.5.3` with the desired version). This adds the dependency to your `build.zig.zon`.
+    (Replace `v3.6.0` with the desired version). This adds the dependency to your `build.zig.zon`.
 
 2.  Add `zli` to your executable in `build.zig`:
 
@@ -649,6 +649,7 @@ Configuration for a `Command`.
 
 - `.name: []const u8`
 - `.shortcut: ?[]const u8 = null`
+- `.aliases: ?[]const []const u8 = null`
 - `.description: ?[]const u8 = null`
 - `.version: ?[]const u8 = null`
 - `.deprecated: bool = false` (or similar for deprecation message)


### PR DESCRIPTION
Introduce command alias functionality in `CommandOptions` and related methods. Update the version number to 3.6.0 in relevant files and documentation.