### PR TITLE
Clarify pointer types in CommandContext, Update version to 3.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ All batteries included.
 [![Zig Version](https://img.shields.io/badge/Zig_Version-0.14.1-orange.svg?logo=zig)](README.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-lightgrey.svg?logo=cachet)](LICENSE)
 [![Built by xcaeser](https://img.shields.io/badge/Built%20by-@xcaeser-blue)](https://github.com/xcaeser)
-[![Version](https://img.shields.io/badge/ZLI-v3.6.2-green)](https://github.com/xcaeser/zli/releases)
+[![Version](https://img.shields.io/badge/ZLI-v3.6.3-green)](https://github.com/xcaeser/zli/releases)
 
 > 🧱 Each command is modular and self-contained.
 >
@@ -32,7 +32,7 @@ See [docs.md](docs.md) for full usage, examples, and internals.
 ## 📦 Installation
 
 ```sh
-zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.6.2.tar.gz
+zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.6.3.tar.gz
 ```
 
 Add to your `build.zig`:

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zli,
-    .version = "3.6.2",
+    .version = "3.6.3",
     .fingerprint = 0x5b01c9c3a623e52d, // Changing this has security and trust implications.
     .minimum_zig_version = "0.14.0",
     .dependencies = .{},

--- a/docs.md
+++ b/docs.md
@@ -105,10 +105,10 @@ Positional arguments are values passed to a command after its name and flags, id
 1.  Fetch `zli` as a dependency using Zig's package manager:
 
     ```sh
-    zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.6.2.tar.gz
+    zig fetch --save=zli https://github.com/xcaeser/zli/archive/v3.6.3.tar.gz
     ```
 
-    (Replace `v3.6.2` with the desired version). This adds the dependency to your `build.zig.zon`.
+    (Replace `v3.6.3` with the desired version). This adds the dependency to your `build.zig.zon`.
 
 2.  Add `zli` to your executable in `build.zig`:
 

--- a/src/zli.zig
+++ b/src/zli.zig
@@ -55,8 +55,8 @@ pub const PositionalArg = struct {
 };
 
 pub const CommandContext = struct {
-    root: *const Command,
-    direct_parent: *const Command,
+    root: *Command,
+    direct_parent: *Command,
     command: *Command,
     allocator: std.mem.Allocator,
     positional_args: []const []const u8,


### PR DESCRIPTION
Clarify pointer types in the CommandContext struct for better readability. Update the version number to 3.6.3 in the README, build configuration, and documentation.