### PR TITLE
fix: flush writer before process.exit in help handler

### DIFF
--- a/src/zli.zig
+++ b/src/zli.zig
@@ -595,6 +595,7 @@ pub const Command = struct {
                 (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")))
             {
                 try self.printHelp();
+                try self.writer.flush();
                 std.process.exit(0);
             }
 


### PR DESCRIPTION
> problem

when using `--help` or `-h` flags, `parseArgsAndFlags` calls `printHelp()` then immediately exits with `std.process.exit(0)`. if the caller uses a buffered writer (which is standard practice), the output remains in the buffer and is never written to stdout.

> reproduction

```zig
var w_buf: [1024]u8 = undefined;
var w_wrap = fs.File.stdout().writer(&w_buf);
const w: *std.Io.Writer = &w_wrap.interface;

const root = try cli.build(w, r, allocator);
try root.execute(.{});
try w.flush();  // never reached when --help is passed
```

running with `--help` produces no output.

> fix

add `try self.writer.flush();` before `std.process.exit(0)` in the help handling path (line ~597).

```zig
try self.printHelp();
try self.writer.flush();  // ensure buffer is drained
std.process.exit(0);
```