### PR TITLE
Refactor parseArgs function visibility to private

### DIFF
--- a/src/zli.zig
+++ b/src/zli.zig
@@ -841,7 +841,7 @@ const ParserOutput = struct {
     }
 };
 
-pub fn parseArgs(self: *Command, argsIterator: *std.process.Args.Iterator) CommandParseErrors!ParserOutput { // needs to give back a cmd context
+fn parseArgs(self: *Command, argsIterator: *std.process.Args.Iterator) CommandParseErrors!ParserOutput { // needs to give back a cmd context
     var current_cmd = self;
     const allocator = current_cmd.init_options.allocator;
 


### PR DESCRIPTION
Change the visibility of the `parseArgs` function to private to encapsulate its usage within the module.