### PR TITLE
Update version to v5.1.1 and refine help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Batteries included. [ZLI reference docs](https://xcaeser.github.io/zli)
 [![Zig Version](https://img.shields.io/badge/Zig_Version-0.16.0-orange.svg?logo=zig)](README.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-lightgrey.svg?logo=cachet)](LICENSE)
 [![Built by xcaeser](https://img.shields.io/badge/Built%20by-@xcaeser-blue)](https://github.com/xcaeser)
-[![Version](https://img.shields.io/badge/ZLI-v5.1.0-green)](https://github.com/xcaeser/zli/releases)
+[![Version](https://img.shields.io/badge/ZLI-v5.1.1-green)](https://github.com/xcaeser/zli/releases)
 
 ## 🚀 Features
 
@@ -24,7 +24,7 @@ Batteries included. [ZLI reference docs](https://xcaeser.github.io/zli)
 ## 📦 Installation
 
 ```sh
-zig fetch --save=zli https://github.com/xcaeser/zli/archive/v5.1.0.tar.gz
+zig fetch --save=zli https://github.com/xcaeser/zli/archive/v5.1.1.tar.gz
 ```
 
 Add to your `build.zig`:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,36 +1,10 @@
 ## zli v5.1.1
 
-This release focuses on smoother command parsing, persistent flags, and friendlier onboarding for new users.
+Patch release focused on help output polish and release metadata.
 
-### Migration note
+### Fixed
 
-- CLI binaries should call `Command.runAndExit`; `Command.execute` now returns parser/execution errors for tests, embedding, and custom error handling instead of exiting the process directly.
+- Removed redundant trailing help guidance from regular command help output.
+- Updated package version metadata to `5.1.1`.
 
-### Added
-
-- Added persistent flags with `.persistent = true`, so parent command flags are automatically available to registered subcommands.
-- Added support for negated boolean flags using `--no-flag`, which sets boolean flags to `false`.
-- Added `Command.runAndExit` for full CLI binaries that should terminate with process exit codes.
-- Added the public `CommandErrors` error set for command parsing and validation failures.
-- Added explicit command error aliases to function signatures for setup, parsing, and printing flows.
-- Added a single-file quick start in the README showing root command initialization, execution, flags, and a subcommand without splitting the CLI across multiple files.
-- Added Zig `0.16.0` package metadata via `.minimum_zig_version`.
-
-### Improved
-
-- Reworked command argument parsing to handle command traversal, long flags, grouped short flags, flag values, and positional arguments through a single parser flow.
-- Improved validation and error messages for missing flag values, invalid flag values, unknown flags, unknown commands, and positional argument count mismatches.
-- Kept `Command.execute` library-friendly by returning parser/execution errors instead of exiting directly.
-- Fixed spinner cursor restoration so hidden cursors are shown again after stopping or deinitializing a spinner.
-- Fixed spinner refresh-rate handling so `stop` no longer hangs waiting on a thread sleeping with nanoseconds interpreted as milliseconds.
-- Tightened spinner lifecycle handling around repeated starts, message updates, and empty frame sets.
-- Improved version output by flushing the writer after `printVersion`.
-- Updated README badges and install command for `v5.1.1`.
-
-### Changed
-
-- Replaced older inline flag parsing internals with the new parser path used by `Command.execute`.
-- Marked persistent flags as complete in the README feature checklist.
-- Added `.DS_Store` and `.idea` to `.gitignore`.
-
-Full changelog: https://github.com/xcaeser/zli/compare/v5.0.0...v5.1.1
+Full changelog: https://github.com/xcaeser/zli/compare/v5.1.0...v5.1.1

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,4 +1,4 @@
-## zli v5.1.0
+## zli v5.1.1
 
 This release focuses on smoother command parsing, persistent flags, and friendlier onboarding for new users.
 
@@ -25,7 +25,7 @@ This release focuses on smoother command parsing, persistent flags, and friendli
 - Fixed spinner refresh-rate handling so `stop` no longer hangs waiting on a thread sleeping with nanoseconds interpreted as milliseconds.
 - Tightened spinner lifecycle handling around repeated starts, message updates, and empty frame sets.
 - Improved version output by flushing the writer after `printVersion`.
-- Updated README badges and install command for `v5.1.0`.
+- Updated README badges and install command for `v5.1.1`.
 
 ### Changed
 
@@ -33,4 +33,4 @@ This release focuses on smoother command parsing, persistent flags, and friendli
 - Marked persistent flags as complete in the README feature checklist.
 - Added `.DS_Store` and `.idea` to `.gitignore`.
 
-Full changelog: https://github.com/xcaeser/zli/compare/v5.0.0...v5.1.0
+Full changelog: https://github.com/xcaeser/zli/compare/v5.0.0...v5.1.1

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zli,
-    .version = "5.1.0",
+    .version = "5.1.1",
     .fingerprint = 0x5b01c9c3a623e52d,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{},

--- a/src/zli.zig
+++ b/src/zli.zig
@@ -535,19 +535,6 @@ pub const Command = struct {
 
             // Arguments
             try self.printPositionalArgs();
-
-            const has_subcommands = self.commands_by_name.count() > 0;
-
-            try self.init_options.writer.print("Use \"", .{});
-            for (parents.items) |p| {
-                try self.init_options.writer.print("{s} ", .{p.cmd_options.name});
-            }
-            try self.init_options.writer.print("{s}", .{self.cmd_options.name});
-
-            if (has_subcommands) {
-                try self.init_options.writer.print(" [command]", .{});
-            }
-            try self.init_options.writer.print(" --help\" for more information.\n", .{});
         }
     }
 


### PR DESCRIPTION
Remove redundant help message printing and update version metadata to reflect the new release. Adjust documentation to align with the changes made in the help output.