### PR TITLE
fix(spinner): flush after each frame so spinners animate

### DIFF
--- a/src/lib/spinner.zig
+++ b/src/lib/spinner.zig
@@ -227,6 +227,7 @@ fn spinLoop(self: *Spinner) void {
         const index = self.frame_index.load(.acquire);
         self.writer.print(clear_line, .{}) catch {};
         self.writer.print("{s}{s}", .{ self.frames[index], self.message }) catch {};
+        self.writer.flush() catch {};
 
         self.frame_index.store((index + 1) % self.frames.len, .release);
         const refresh_rate_ms = self.refresh_rate_ms;


### PR DESCRIPTION
Spinners don't animate:`spinLoop` writes each frame via `print` but never flushes, so with the buffered `Io.File.Writer` shown in the README quick-start, frames accumulate in the write buffer and only reach the terminal when the buffer fills or another path flushes it. For short steps this shows no visible motion.

`hideCursor`/`showCursor` already call `self.writer.flush()`, this change adds it to the animation loop.

Scope: `print` and `finalize` also write without flushing, but this doesn't cause any issues in my testing.
